### PR TITLE
replace reset cfg w/ scrapligo, fix type checking for transport types

### DIFF
--- a/topo/node/ceos/ceos.go
+++ b/topo/node/ceos/ceos.go
@@ -17,9 +17,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	scraplitest "github.com/scrapli/scrapligo/util/testhelper"
 	"io"
 	"io/ioutil"
-	"reflect"
 	"time"
 
 	topopb "github.com/google/kne/proto/topo"
@@ -27,6 +27,7 @@ import (
 	scraplibase "github.com/scrapli/scrapligo/driver/base"
 	scraplicore "github.com/scrapli/scrapligo/driver/core"
 	scraplinetwork "github.com/scrapli/scrapligo/driver/network"
+	scraplitransport "github.com/scrapli/scrapligo/transport"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -79,24 +80,16 @@ func (n *Node) WaitCLIReady() error {
 
 // PatchCLIConnOpen sets the OpenCmd and ExecCmd of system transport to work with `kubectl exec` terminal.
 func (n *Node) PatchCLIConnOpen(ns string) error {
-	tIntf := reflect.ValueOf(n.cliConn.Transport)
-
-	if tIntf.Type().Kind() != reflect.Ptr {
-		tIntf = reflect.New(reflect.TypeOf(n.cliConn.Transport))
-	}
-
-	execCmd := tIntf.Elem().FieldByName("ExecCmd")
-	openCmd := tIntf.Elem().FieldByName("OpenCmd")
-
-	if !execCmd.IsValid() || !openCmd.IsValid() {
-		// this *shouldn't* happen ever, but it is possible an invalid scrapli transport type gets set.
+	switch t := n.cliConn.Transport.(type) {
+	case *scraplitest.TestingTransport:
+		t.ExecCmd = "kubectl"
+		t.OpenCmd = []string{"exec", "-it", "-n", ns, n.pb.Name, "--", "Cli"}
+	case *scraplitransport.System:
+		t.ExecCmd = "kubectl"
+		t.OpenCmd = []string{"exec", "-it", "-n", ns, n.pb.Name, "--", "Cli"}
+	default:
 		return ErrIncompatibleCliConn
 	}
-
-	execCmd.SetString("kubectl")
-	openCmd.Set(
-		reflect.ValueOf([]string{"exec", "-it", "-n", ns, n.pb.Name, "--", "Cli"}),
-	)
 
 	return nil
 }
@@ -108,6 +101,8 @@ func (n *Node) SpawnCLIConn(ns string) error {
 		n.pb.Name,
 		"arista_eos",
 		scraplibase.WithAuthBypass(true),
+		// disable transport timeout
+		scraplibase.WithTimeoutTransport(0),
 	)
 	if err != nil {
 		return err
@@ -219,32 +214,26 @@ func (n *Node) ConfigPush(ctx context.Context, ns string, r io.Reader) error {
 }
 
 func (n *Node) ResetCfg(ctx context.Context, ni node.Interface) error {
-	log.Infof("Resetting config on %s:%s", ni.Namespace(), n.pb.Name)
-	cmd := fmt.Sprintf("kubectl exec -it -n %s %s -- Cli", ni.Namespace(), n.pb.Name)
-	g, _, err := spawner(cmd, -1)
+	log.Infof("%s resetting config", n.pb.Name)
+
+	err := n.SpawnCLIConn(ni.Namespace())
 	if err != nil {
 		return err
 	}
-	_, _, err = g.Expect(regexp.MustCompile(`>`), -1)
+
+	defer n.cliConn.Close()
+
+	// this takes a long time sometimes, so we crank timeouts up
+	resp, err := n.cliConn.SendCommand("configure replace clean-config", scraplibase.WithSendTimeoutOps(300 * time.Second))
 	if err != nil {
 		return err
+	} else if resp.Failed {
+		return ErrCliOperationFailed
 	}
-	if err := g.Send("enable\n"); err != nil {
-		return err
-	}
-	_, _, err = g.Expect(regexp.MustCompile(`#`), -1)
-	if err != nil {
-		return err
-	}
-	if err := g.Send("configure replace clean-config\n"); err != nil {
-		return err
-	}
-	_, _, err = g.Expect(regexp.MustCompile(`#`), -1)
-	if err != nil {
-		return err
-	}
-	log.Info("Configuration reset")
-	return g.Close()
+
+	log.Infof("%s - finshed resetting config", n.pb.Name)
+
+	return nil
 }
 
 func (n *Node) CreateNodeResource(_ context.Context, _ node.Interface) error {

--- a/topo/node/ceos/ceos.go
+++ b/topo/node/ceos/ceos.go
@@ -17,10 +17,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	scraplitest "github.com/scrapli/scrapligo/util/testhelper"
 	"io"
 	"io/ioutil"
 	"time"
+
+	scraplitest "github.com/scrapli/scrapligo/util/testhelper"
 
 	topopb "github.com/google/kne/proto/topo"
 	"github.com/google/kne/topo/node"
@@ -224,7 +225,10 @@ func (n *Node) ResetCfg(ctx context.Context, ni node.Interface) error {
 	defer n.cliConn.Close()
 
 	// this takes a long time sometimes, so we crank timeouts up
-	resp, err := n.cliConn.SendCommand("configure replace clean-config", scraplibase.WithSendTimeoutOps(300 * time.Second))
+	resp, err := n.cliConn.SendCommand(
+		"configure replace clean-config",
+		scraplibase.WithSendTimeoutOps(300*time.Second),
+	)
 	if err != nil {
 		return err
 	} else if resp.Failed {

--- a/topo/node/ceos/ceos_test.go
+++ b/topo/node/ceos/ceos_test.go
@@ -173,83 +173,88 @@ func TestGenerateSelfSigned(t *testing.T) {
 }
 
 func TestResetCfg(t *testing.T) {
+	ki := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1",
+		},
+	})
+
+	reaction := func(action ktest.Action) (handled bool, ret watch.Interface, err error) {
+		f := &fakeWatch{
+			e: []watch.Event{{
+				Object: &corev1.Pod{
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			}},
+		}
+		return true, f, nil
+	}
+	ki.PrependWatchReactor("*", reaction)
+
+	ni := &fakeNode{
+		kClient:   ki,
+		namespace: "test",
+	}
+
+	validPb := &topopb.Node{
+		Name: "pod1",
+		Type: 2,
+		Config: &topopb.Config{},
+	}
+
 	tests := []struct {
-		desc    string
-		wantErr string
-		ni      node.Interface
-		pb      *topopb.Node
-		spawner func(string, time.Duration, ...expect.Option) (expect.Expecter, <-chan error, error)
-	}{{
-		desc: "valid Reset",
-		pb:   validPb,
-		ni: &fakeNode{
-			namespace: "test",
+		desc     string
+		wantErr  bool
+		ni       node.Interface
+		pb       *topopb.Node
+		testFile string
+	}{
+		{
+			// successfully configure certificate
+			desc:     "success",
+			wantErr:  false,
+			ni:       ni,
+			pb:       validPb,
+			testFile: "reset_config_success",
 		},
-		spawner: fakeSpawner(&fakeExpect{
-			expects: []expects{
-				{resp: "some stuff>"}, // base
-				{resp: "prompt#"},     // enable
-				{resp: "prompt#"},     // reset
-			},
-			sends: []sends{
-				{err: nil}, // enable
-				{err: nil}, // reset
-			},
-		}),
-	}, {
-		desc: "failed send",
-		pb:   validPb,
-		ni: &fakeNode{
-			namespace: "test",
+		{
+			// device returns "% Invalid Input" -- we expect to fail
+			desc:     "failure",
+			wantErr:  true,
+			ni:       ni,
+			pb:       validPb,
+			testFile: "reset_config_failure",
 		},
-		spawner: fakeSpawner(&fakeExpect{
-			expects: []expects{
-				{resp: "some stuff>"}, // base
-				{resp: "prompt#"},     // enable
-				{resp: "prompt#"},     // reset
-			},
-			sends: []sends{
-				{err: fmt.Errorf("send error")}, // enable
-				{err: nil},                      // reset
-			},
-		}),
-		wantErr: "send error",
-	}, {
-		desc: "failed config send",
-		pb:   validPb,
-		ni: &fakeNode{
-			namespace: "test",
-		},
-		spawner: fakeSpawner(&fakeExpect{
-			expects: []expects{
-				{resp: "some stuff>"}, // base
-				{resp: "prompt#"},     // enable
-				{resp: "prompt#"},     // reset
-			},
-			sends: []sends{
-				{err: nil},                      // enable
-				{err: fmt.Errorf("send error")}, // reset
-			},
-		}),
-		wantErr: "send error",
-	}}
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			spawner = tt.spawner
-			timeSecond = 0
-			defer func() {
-				spawner = defaultSpawner
-				timeSecond = time.Second
-			}()
-			nImpl, _ := New(tt.pb)
-			n := nImpl.(*Node)
-			ctx := context.Background()
-			err := n.ResetCfg(ctx, tt.ni)
-			if s := errdiff.Check(err, tt.wantErr); s != "" {
-				t.Fatalf("ResetCfg unexpected error: %s", s)
+			nImpl, err := New(tt.pb)
+
+			if err != nil {
+				t.Fatalf("failed creating kne arista node")
 			}
-			if tt.wantErr != "" {
-				return
+
+			n, _ := nImpl.(*Node)
+
+			oldNewCoreDriver := scraplicore.NewCoreDriver
+			defer func() { scraplicore.NewCoreDriver = oldNewCoreDriver }()
+			scraplicore.NewCoreDriver = func(host, platform string, options ...scraplibase.Option) (*scraplinetwork.Driver, error) {
+				return scraplicore.NewEOSDriver(
+					host,
+					scraplibase.WithAuthBypass(true),
+					scraplibase.WithTimeoutOps(1*time.Second),
+					scraplitest.WithPatchedTransport(tt.testFile),
+				)
+			}
+
+			ctx := context.Background()
+
+			err = n.ResetCfg(ctx, ni)
+			if err != nil && !tt.wantErr {
+				t.Fatalf("resetting config failed, error: %+v\n", err)
 			}
 		})
 	}

--- a/topo/node/ceos/ceos_test.go
+++ b/topo/node/ceos/ceos_test.go
@@ -199,8 +199,8 @@ func TestResetCfg(t *testing.T) {
 	}
 
 	validPb := &topopb.Node{
-		Name: "pod1",
-		Type: 2,
+		Name:   "pod1",
+		Type:   2,
 		Config: &topopb.Config{},
 	}
 

--- a/topo/node/ceos/reset_config_failure
+++ b/topo/node/ceos/reset_config_failure
@@ -1,0 +1,27 @@
+spine1>enable
+spine1#
+spine1#terminal length 0
+Pagination disabled.
+spine1#terminal width 32767
+Width set to 32767 columns.
+spine1#
+spine1#configure replace clean-config
+Aug 21 18:37:16 localhost Launcher: %LAUNCHER-6-PROCESS_STOP: Configuring process 'CapiApp' to stop in role 'ActiveSupervisor'
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-STABLE_CHANGE: Stp state is now not stable
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet11 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet19 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet6 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet13 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet10 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet7 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet8 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet12 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet2 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet20 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet18 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet17 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet9 has been added to instance MST0
+% Invalid Input
+spine1#
+spine1#
+spine1#

--- a/topo/node/ceos/reset_config_success
+++ b/topo/node/ceos/reset_config_success
@@ -1,0 +1,27 @@
+spine1>enable
+spine1#
+spine1#terminal length 0
+Pagination disabled.
+spine1#terminal width 32767
+Width set to 32767 columns.
+spine1#
+spine1#configure replace clean-config
+Aug 21 18:37:16 localhost Launcher: %LAUNCHER-6-PROCESS_STOP: Configuring process 'CapiApp' to stop in role 'ActiveSupervisor'
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-STABLE_CHANGE: Stp state is now not stable
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet11 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet19 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet6 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet13 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet10 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet7 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet8 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet12 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet2 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet20 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet18 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet17 has been added to instance MST0
+Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet9 has been added to instance MST0
+Aug 21 18:37:17 localhost ConfigAgent: %SYS-5-CONFIG_REPLACE_SUCCESS: User boxen replaced running configuration with session:/clean-session-config successfully on con0 (0.0.0.0)
+localhost#
+localhost#
+localhost#


### PR DESCRIPTION
fixes the import issue -- I had removed tests when I was playing around trying to understand things, so when we merged my previous pr we ended up with those tests still there but the imports removed. so I just replaced the reset cfg with scrapligo.

fixes (removes) the reflection piece.