### PR TITLE
Reset cfg test

### DIFF
--- a/topo/node/srl/reset_config_failure
+++ b/topo/node/srl/reset_config_failure
@@ -16,15 +16,7 @@ A:pod1# info from state system configuration commit 1 status | grep complete
 A:pod1# enter candidate private
 --{ candidate private private-admin }--[  ]--
 A:pod1# load factory auto-commit  
-/system/configuration/checkpoint[id=__factory__]:
-    Reverting to factory configuration
-
-/:
-    Preamble must be present in configuration file
-
-/:
-    Successfully reverted configuration
-
+Error: something bad happened
 --{ + candidate private private-admin }--[  ]--
 A:pod1#
 --{ + candidate private private-admin }--[  ]--

--- a/topo/node/srl/reset_config_success
+++ b/topo/node/srl/reset_config_success
@@ -28,4 +28,9 @@ A:pod1# load factory auto-commit
 --{ + candidate private private-admin }--[  ]--
 A:pod1#
 --{ + candidate private private-admin }--[  ]--
-A:pod1#
+A:pod1# discard now 
+Nothing to discard. Leaving candidate mode.
+--{ + running }--[  ]--
+A:pod1
+--{ + running }--[  ]--
+A:pod1

--- a/topo/node/srl/reset_config_success
+++ b/topo/node/srl/reset_config_success
@@ -1,0 +1,31 @@
+Using configuration file(s): []
+Welcome to the srlinux CLI.
+Type 'help' (and press <ENTER>) if you need any help using this.
+Warning: Running in basic cli engine, only limited set of features is enabled.
+--{ running }--[  ]--
+A:pod1# environment cli-engine type basic
+--{ running }--[  ]--
+A:pod1# environment complete-on-space false
+--{ + running }--[  ]--
+A:pod1# info from state system app-management application mgmt_server state | grep running
+                state running
+--{ running }--[  ]--
+A:pod1# info from state system configuration commit 1 status | grep complete
+                status complete
+--{ running }--[  ]--
+A:pod1# enter candidate private
+--{ candidate private private-admin }--[  ]--
+A:pod1# load factory auto-commit  
+/system/configuration/checkpoint[id=__factory__]:
+    Reverting to factory configuration
+
+/:
+    Preamble must be present in configuration file
+
+/:
+    Successfully reverted configuration
+
+--{ + candidate private private-admin }--[  ]--
+A:pod1#
+--{ + candidate private private-admin }--[  ]--
+A:pod1#

--- a/topo/node/srl/srl.go
+++ b/topo/node/srl/srl.go
@@ -84,8 +84,6 @@ func (n *Node) GenerateSelfSigned(ctx context.Context) error {
 		return err
 	}
 
-	defer n.cliConn.Close()
-
 	err = srlinux.AddSelfSignedServerTLSProfile(n.cliConn, selfSigned.CertName, false)
 	if err != nil {
 		return err
@@ -93,7 +91,7 @@ func (n *Node) GenerateSelfSigned(ctx context.Context) error {
 
 	log.Infof("%s - finished cert generation", n.Name())
 
-	return err
+	return n.cliConn.Close()
 }
 
 // Create creates a Nokia SR Linux node by interfacing with srl-labs/srl-controller
@@ -243,8 +241,6 @@ func (n *Node) ResetCfg(ctx context.Context) error {
 		return err
 	}
 
-	defer n.cliConn.Close()
-
 	resp, err := n.cliConn.SendConfig(
 		configResetCmd,
 	)
@@ -257,7 +253,7 @@ func (n *Node) ResetCfg(ctx context.Context) error {
 	}
 	log.Infof("%s - finished resetting config", n.Name())
 
-	return nil
+	return n.cliConn.Close()
 }
 
 // SpawnCLIConn spawns a CLI connection towards a Network OS using `kubectl exec` terminal and ensures CLI is ready

--- a/topo/node/srl/srl.go
+++ b/topo/node/srl/srl.go
@@ -255,7 +255,7 @@ func (n *Node) ResetCfg(ctx context.Context) error {
 	if resp.Failed != nil {
 		return resp.Failed
 	}
-	log.Infof("%s - finshed resetting config", n.Name())
+	log.Infof("%s - finished resetting config", n.Name())
 	return nil
 }
 

--- a/topo/node/srl/srl.go
+++ b/topo/node/srl/srl.go
@@ -245,7 +245,7 @@ func (n *Node) ResetCfg(ctx context.Context) error {
 
 	defer n.cliConn.Close()
 
-	resp, err := n.cliConn.SendCommand(
+	resp, err := n.cliConn.SendConfig(
 		configResetCmd,
 	)
 	if err != nil {
@@ -256,6 +256,7 @@ func (n *Node) ResetCfg(ctx context.Context) error {
 		return resp.Failed
 	}
 	log.Infof("%s - finished resetting config", n.Name())
+
 	return nil
 }
 

--- a/topo/node/srl/srl_test.go
+++ b/topo/node/srl/srl_test.go
@@ -206,7 +206,8 @@ func TestGenerateSelfSigned(t *testing.T) {
 			}
 
 			if scrapliDebug() {
-				li, _ := scraplilogging.NewInstance(scraplilogging.WithLevel("debug"),
+				li, _ := scraplilogging.NewInstance(
+					scraplilogging.WithLevel("debug"),
 					scraplilogging.WithLogger(t.Log))
 				n.testOpts = append(n.testOpts, scrapliopts.WithLogger(li))
 			}
@@ -294,7 +295,8 @@ func TestResetCfg(t *testing.T) {
 			}
 
 			if scrapliDebug() {
-				li, _ := scraplilogging.NewInstance(scraplilogging.WithLevel("debug"),
+				li, _ := scraplilogging.NewInstance(
+					scraplilogging.WithLevel("debug"),
 					scraplilogging.WithLogger(t.Log))
 				n.testOpts = append(n.testOpts, scrapliopts.WithLogger(li))
 			}


### PR DESCRIPTION
Hey @carlmontanari
I know you sup busy, so whenver you're there I'd appreaciate your expert opinion on a strange thing I see in scrapligo (v1.2.2) test.

Namely in this PR you see a newly added test function added called [`TestResetCfg`](https://github.com/hellt/kne/pull/3/files#diff-cc7c9bbccf42876704db91e3363380a8b1bf57b5528bca6f7f157db240361a90R221) which acts on an file input with send/recv chars.
The issue I am seeing is that scrapligo doesn't emit an error when the written bytes don't match the received ones.

Here is a snippet from the test execution with verbose logging:
`go test -timeout 30s -v -run ^TestResetCfg$ github.com/openconfig/kne/topo/node/srl`
```
/root/openconfig/kne/topo/node/srl/logging.go:54:     INFO SendCommand requested, sending 'load factory auto-commit'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel SendInput requested, sending input 'load factory auto-commit'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "load factory auto-commit"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read " enter candidate private\n--{ candidate private private-admin }--[  ]--\nA:pod1# load factory auto-commit"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "\n"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read "  \n/system/configuration/checkpoint[id=__factory__]:\n    Reverting to factory configuration\n\n/:\n    Preamble must be present in configuration file\n\n/:\n    Successfully reverted configuration\n\n--{ + candidate private private-admin }--[  ]--\nA:pod1#"
time="2022-08-04T16:38:52+02:00" level=info msg="pod1 - finished resetting config"
```

The bad stuff happens on line 3, where we write `load factory auto-commit`, but we read back some other line and no error is sent back.

Full log below
<details>
```
Running tool: /root/sdk/go1.18.4/bin/go test -timeout 30s -run ^TestResetCfg$ github.com/openconfig/kne/topo/node/srl

=== RUN   TestResetCfg
=== RUN   TestResetCfg/success
time="2022-08-04T16:38:52+02:00" level=info msg="pod1 resetting config"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG opening connection to host 'pod1' on port '22'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG starting channel read loop
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG auth bypass is enabled, skipping in channel auth check
    /root/openconfig/kne/topo/node/srl/logging.go:54:     INFO connection opened successfully
    /root/openconfig/kne/topo/node/srl/logging.go:54:     INFO AcquirePriv requested, target privilege level 'exec'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel GetPrompt requested
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "\n"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read "Using configuration file(s): []\nWelcome to the srlinux CLI.\nType 'help' (and press <ENTER>) if you need any help using this.\nWarning: Running in basic cli engine, only limited set of features is enabled.\n--{ running }--[  ]--\nA:pod1#"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG AcquirePriv determined no privilege action necessary
    /root/openconfig/kne/topo/node/srl/logging.go:54:     INFO SendCommand requested, sending 'environment cli-engine type basic'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel SendInput requested, sending input 'environment cli-engine type basic'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "environment cli-engine type basic"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read " environment cli-engine type basic"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "\n"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read "\n--{ running }--[  ]--\nA:pod1#"
    /root/openconfig/kne/topo/node/srl/logging.go:54:     INFO SendCommand requested, sending 'environment complete-on-space false'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel SendInput requested, sending input 'environment complete-on-space false'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "environment complete-on-space false"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read " environment complete-on-space false"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "\n"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read "\n--{ + running }--[  ]--\nA:pod1#"
    /root/openconfig/kne/topo/node/srl/logging.go:54:     INFO SendCommand requested, sending 'info from state system app-management application mgmt_server state | grep running'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel SendInput requested, sending input 'info from state system app-management application mgmt_server state | grep running'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "info from state system app-management application mgmt_server state | grep running"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read " info from state system app-management application mgmt_server state | grep running"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "\n"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read "\n                state running\n--{ running }--[  ]--\nA:pod1#"
    /root/openconfig/kne/topo/node/srl/logging.go:54:     INFO SendCommand requested, sending 'info from state system configuration commit 1 status | grep complete'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel SendInput requested, sending input 'info from state system configuration commit 1 status | grep complete'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "info from state system configuration commit 1 status | grep complete"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read " info from state system configuration commit 1 status | grep complete"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "\n"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read "\n                status complete\n--{ running }--[  ]--\nA:pod1#"
    /root/openconfig/kne/topo/node/srl/logging.go:54:     INFO SendCommand requested, sending 'load factory auto-commit'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel SendInput requested, sending input 'load factory auto-commit'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "load factory auto-commit"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read " enter candidate private\n--{ candidate private private-admin }--[  ]--\nA:pod1# load factory auto-commit"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "\n"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read "  \n/system/configuration/checkpoint[id=__factory__]:\n    Reverting to factory configuration\n\n/:\n    Preamble must be present in configuration file\n\n/:\n    Successfully reverted configuration\n\n--{ + candidate private private-admin }--[  ]--\nA:pod1#"
time="2022-08-04T16:38:52+02:00" level=info msg="pod1 - finished resetting config"
    /root/openconfig/kne/topo/node/srl/logging.go:54:     INFO AcquirePriv requested, target privilege level 'exec'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel GetPrompt requested
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "\n"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel read "\n--{ + candidate private private-admin }--[  ]--\nA:pod1#"
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG AcquirePriv determined privilege de-escalation necessary
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel SendInput requested, sending input 'discard now'
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG channel write "discard now"
    /root/openconfig/kne/topo/node/srl/logging.go:54: CRITICAL channel timeout sending input to device
    /root/openconfig/kne/topo/node/srl/logging.go:54: CRITICAL error running network on close, error: errTimeoutError: channel timeout sending input to device
    /root/openconfig/kne/topo/node/srl/logging.go:54:    DEBUG closing connection to host 'pod1' on port '22'
    /root/openconfig/kne/topo/node/srl/logging.go:54:     INFO connection closed successfully
--- PASS: TestResetCfg (2.01s)
    --- PASS: TestResetCfg/success (2.01s)
PASS
ok      github.com/openconfig/kne/topo/node/srl 2.029s
```
</details>